### PR TITLE
Allow multiple writes per block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ journalling-benchmark.*
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+.gradle/
+.idea/
+build/

--- a/src/main/java/com/epickrram/benchmark/journal/Journaller.java
+++ b/src/main/java/com/epickrram/benchmark/journal/Journaller.java
@@ -9,6 +9,6 @@ public interface Journaller
     int BLOCK_SIZE = 4096;
     long DELAY_BETWEEN_BLOCKS_NANOS = TimeUnit.MICROSECONDS.toNanos(50L);
 
-    void write(final ByteBuffer data) throws IOException;
+    void write(final ByteBuffer data, boolean newBlock) throws IOException;
     void complete();
 }

--- a/src/main/java/com/epickrram/benchmark/journal/TestMain.java
+++ b/src/main/java/com/epickrram/benchmark/journal/TestMain.java
@@ -57,12 +57,12 @@ public final class TestMain
         final TimingJournaller timingJournaller = new TimingJournaller(journaller);
 
         System.out.println("Doing warm-up");
-        new Driver(bufferFactory, timingJournaller, config.fileCount, config.fileSize, 1).execute();
+        new Driver(bufferFactory, timingJournaller, config.fileCount, config.fileSize, 1, config.writesPerBlock).execute();
 
         timingJournaller.setRecording(true);
 
         System.out.println("Starting measurement for journaller " + config.journallerType);
-        new Driver(bufferFactory, timingJournaller, config.fileCount, config.fileSize, config.measurementIterations).execute();
+        new Driver(bufferFactory, timingJournaller, config.fileCount, config.fileSize, config.measurementIterations, config.writesPerBlock).execute();
     }
 
     private static void preallocateFiles(final Config config, final Path journalDir) throws IOException
@@ -84,6 +84,8 @@ public final class TestMain
         private int measurementIterations = 5;
         @Parameter(names = "-h", description = "show help", help = true)
         private boolean help;
+        @Parameter(names = "-w", description = "writes per block")
+        private int writesPerBlock = 1;
     }
 
     private static Function<Path, RandomAccessFile> randomAccessFileFactory()

--- a/src/main/java/com/epickrram/benchmark/journal/impl/PositionalWriteJournaller.java
+++ b/src/main/java/com/epickrram/benchmark/journal/impl/PositionalWriteJournaller.java
@@ -14,10 +14,11 @@ public final class PositionalWriteJournaller extends AbstractJournaller<FileChan
     }
 
     @Override
-    public void write(final ByteBuffer data) throws IOException
+    public void write(final ByteBuffer data, boolean newBlock) throws IOException
     {
+        positionInFile += (newBlock) ? data.remaining() : 0;
         assignJournal(data.remaining());
 
-        positionInFile += currentJournal.write(data, positionInFile);
+        currentJournal.write(data, positionInFile);
     }
 }

--- a/src/main/java/com/epickrram/benchmark/journal/impl/SeekThenWriteJournaller.java
+++ b/src/main/java/com/epickrram/benchmark/journal/impl/SeekThenWriteJournaller.java
@@ -12,13 +12,12 @@ public final class SeekThenWriteJournaller extends AbstractJournaller<RandomAcce
     }
 
     @Override
-    public void write(final ByteBuffer data) throws IOException
+    public void write(final ByteBuffer data, boolean newBlock) throws IOException
     {
+        positionInFile += (newBlock) ? data.remaining() : 0;
         assignJournal(data.remaining());
 
         currentJournal.seek(positionInFile);
-        final int messageSize = data.remaining();
         currentJournal.write(data.array(), data.position(), data.remaining());
-        positionInFile += messageSize;
     }
 }

--- a/src/main/java/com/epickrram/benchmark/journal/instrument/TimingJournaller.java
+++ b/src/main/java/com/epickrram/benchmark/journal/instrument/TimingJournaller.java
@@ -24,10 +24,10 @@ public final class TimingJournaller implements Journaller
     }
 
     @Override
-    public void write(final ByteBuffer data) throws IOException
+    public void write(final ByteBuffer data, boolean newBlock) throws IOException
     {
         final long startNanos = System.nanoTime();
-        delegate.write(data);
+        delegate.write(data, newBlock);
 
         final long durationNanos = System.nanoTime() - startNanos;
         if(recording)


### PR DESCRIPTION
To simulate the case where would get multiple events to journal such that we would overwrite the same block multiple times, I've add a '-w' flag which will require the journaller to write the data to the same location in the file multiple times.  This would mean that the journaller would need to seek back to the previous location rather than doing append only, so the seek/pwrite calls will actually need to do some real work.
